### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,31 +7,31 @@ MultiLingualString for Python (2k and 3k)
 .. image:: https://coveralls.io/repos/rembish/mls/badge.svg
     :target: https://coveralls.io/r/rembish/mls
 
-.. image:: https://pypip.in/download/mls/badge.svg
+.. image:: https://img.shields.io/pypi/dm/mls.svg
     :target: https://pypi.python.org/pypi/mls
 
-.. image:: https://pypip.in/version/mls/badge.svg
+.. image:: https://img.shields.io/pypi/v/mls.svg
     :target: https://pypi.python.org/pypi/mls
 
-.. image:: https://pypip.in/py_versions/mls/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/mls.svg
     :target: https://pypi.python.org/pypi/mls
 
-.. image:: https://pypip.in/implementation/mls/badge.svg
+.. image:: https://img.shields.io/pypi/implementation/mls.svg
     :target: https://pypi.python.org/pypi/mls
 
-.. image:: https://pypip.in/status/mls/badge.svg
+.. image:: https://img.shields.io/pypi/status/mls.svg
     :target: https://pypi.python.org/pypi/mls
 
-.. image:: https://pypip.in/wheel/mls/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/mls.svg
     :target: https://pypi.python.org/pypi/mls
 
 .. image:: https://pypip.in/egg/mls/badge.svg
     :target: https://pypi.python.org/pypi/mls
 
-.. image:: https://pypip.in/format/mls/badge.svg
+.. image:: https://img.shields.io/pypi/format/mls.svg
     :target: https://pypi.python.org/pypi/mls
 
-.. image:: https://pypip.in/license/mls/badge.svg
+.. image:: https://img.shields.io/pypi/l/mls.svg
     :target: https://pypi.python.org/pypi/mls
 
 This simple module implements simple unicode-like object, which can contain


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20mls))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `mls`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.